### PR TITLE
Permit super long comment lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ module.exports = {
   "extends": "airbnb-base",
   "rules": {
     "mocha/no-exclusive-tests": "error",
-    "no-console": 0
+    "no-console": 0,
+    "spaced-comment": [0, "never"]
   },
   "parserOptions": {
     "ecmaVersion": 2018,


### PR DESCRIPTION
I find it super helpful to write code like this as  it makes it clear
where different sections of code reside. In this commit I propose that
we permit such comments

```
/
**********************************************
 * Enforcements
 *********************************************/
core.app.enforcements.enforceEnvs();
core.app.enforcements.enforceConfigs(config);

/**********************************************
 * Spin up server
 *********************************************/

const { port } = config.app;
```