### PR TITLE
Add require-await rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ module.exports = {
   "extends": "airbnb-base",
   "rules": {
     "mocha/no-exclusive-tests": "error",
-    "no-underscore-dangle": ["error", { "allowAfterThis": true }]
+    "no-underscore-dangle": ["error", { "allowAfterThis": true }],
+    "require-await": "error"
   },
   "parserOptions": {
     "ecmaVersion": 2018,


### PR DESCRIPTION
In almost every case, an `async` function should be using the `await`
keyword. Otherwise, the function could (and should) be synchronous. Or,
internal promises could be re-written using `await`.

See: https://eslint.org/docs/rules/require-await

However, edge cases are possible, such as error-handling:

https://eslint.org/docs/rules/require-await#when-not-to-use-it

I suggest that in these miniscule cases, we just opt-out of this rule by
adding the following code comment at the top of the file:

```
/* eslint require-await: 0 */
```

What do you think team?