### PR TITLE
correct parser options source type

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   "parserOptions": {
     "ecmaVersion": 2018,
-    "sourceType": "module",
+    "sourceType": "script",
     "ecmaFeatures": {
         "jsx": true
     }


### PR DESCRIPTION
"sourceType: module" is only valid if using ES Modules

Per this link, any module that uses `module.exports` is actually a
commonJs module:

https://github.com/eslint/eslint/issues/5301#issuecomment-184720161

The same is true looking at the eslint docs:

https://eslint.org/docs/user-guide/configuring#specifying-parser-options