### PR TITLE
allow files to import devDependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
     "mocha/no-exclusive-tests": "error",
     "no-underscore-dangle": "off",
     "require-await": "error",
+    "import/no-extraneous-dependencies": ["error", {"optionalDependencies": false, "peerDependencies": false}],
   },
   "parserOptions": {
     "ecmaVersion": 2018,


### PR DESCRIPTION
Currently, the `import/no-extraneous-dependencies` rule is set such that
devDependencies cannot be imported anywhere in an app, including test
files.

Since test packages often will not need to be included in production,
this rule is being updated to allow devDependencies to be imported.